### PR TITLE
fix: set the correct base URL

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -1,7 +1,7 @@
 title = 'Jentz'
 theme = "hugo-coder"
 
-baseURL = "https://example.org/"
+baseURL = "https://jentz.co/"
 languageCode = "en-us"
 defaultcontentlanguage = "en"
 


### PR DESCRIPTION
This pull request includes a small change to the `hugo.toml` file. The `baseURL` has been updated to reflect the new website URL.