### PR TITLE
fix: improve clarity oidc-cli intro

### DIFF
--- a/content/posts/2025-06-23-oidc-cli-intro/index.md
+++ b/content/posts/2025-06-23-oidc-cli-intro/index.md
@@ -45,7 +45,7 @@ authorization request: https://eu-west-1r7zfnvwv0.auth.eu-west-1.amazoncognito.c
 }
 ```
 
-  * The end-user runs `oidc-cli authorization_code`
+  * The end-user runs `oidc-cli authorization_code`.
   * `oidc-cli` parses the options and creates an authorization_code request.
   * `oidc-cli` starts a listener on the redirect URI to receive the auth code.
   * `oidc-cli` tries to open the default browser for the platform to start the flow.
@@ -53,7 +53,7 @@ authorization request: https://eu-west-1r7zfnvwv0.auth.eu-west-1.amazoncognito.c
   * The authorization server authenticates the user.
   * The authentication redirects the browser to the redirect URI.
   * `oidc-cli` receives the auth code and exchanges it for tokens at the token endpoint.
-  * `oidc-cli` pretty prints the token endpoint response body
+  * `oidc-cli` prints the token endpoint response body.
 
 {{<mermaid>}}
 sequenceDiagram
@@ -75,7 +75,7 @@ sequenceDiagram
     RP->>U: Print token response
 {{</mermaid>}}
 
-The token response is output to stdout, while other information is printed on stderr. This allows `oidc-cli` invocations to be chained together with other CLI tools like [jq](https://jqlang.org/), [jwt-cli](https://github.com/mike-engel/jwt-cli), and `pbcopy`.
+The token response is output to stdout, while other information is printed on stderr. This allows `oidc-cli` invocations to be chained with commands like [jq](https://jqlang.org/), [jwt-cli](https://github.com/mike-engel/jwt-cli), and `pbcopy`.
 
 The basic form of the command is:
 
@@ -98,7 +98,7 @@ oidc-cli -verbose authorization_code \
   * **-client-id** is the client ID for the request
   * **-pkce** will cause the request to be protected by proof-key for code exchange (PKCE)
 
-Now will will look at the authorization request more closely and break it down.
+We will look at the authorization request more closely and break it down.
 
 ```
 https://eu-west-1r7zfnvwv0.auth.eu-west-1.amazoncognito.com/oauth2/authorize?
@@ -117,7 +117,7 @@ code_challenge=hL-F4FY4et9NJu7qHnnXyVJS6JdVF05pjosBL6IwKmA
 code_challenge_method=S256
 ```
 
-These parameters are part of the PKCE challenege, they are part of protecting the interaction.
+These parameters are part of the PKCE challenge, they are part of protecting the interaction.
 
 ```
 redirect_uri=http%3A%2F%2Flocalhost%3A9555%2Fcallback
@@ -139,7 +139,7 @@ The scope is `oidc`, which is the default for `oidc-cli`. You can add more scope
 
 # Conclusion
 
-`oidc-cli` is a powerful and intuitive tool for streamlining OIDC and OAuth2 authentication workflows directly from the command line. By simplifying complex authorization processes, like the authorization code flow with PKCE, it empowers developers, DevOps, and IAM professionals to efficiently manage tokens and integrate authentication into their workflows. Its seamless compatibility with tools like `jq`, `jwt-cli`, and `pbcopy` makes it a versatile addition to any CLI-driven process. Whether you're working with public clients, setting up secure authentication, or automating token retrieval, oidc-cli offers a reliable and user-friendly solution. Explore the GitHub repository to get started and enhance your OIDC interactions with ease.
+`oidc-cli` is a powerful and intuitive tool for streamlining OIDC and OAuth2 authentication workflows directly from the command line. Simplifying complex authorization processes, like the authorization code flow with PKCE, empowers developers, DevOps, and IAM professionals to manage tokens and integrate authentication into their workflows efficiently. Its adherence to the UNIX philosophy of small modular commands with clear input and output streams makes it play nicely with tools like `jq`, `jwt-cli`, and `pbcopy`. Explore the GitHub repository to get started and enhance your OIDC interactions with ease.
 
 # References
 


### PR DESCRIPTION
This pull request makes several improvements to the blog post introducing `oidc-cli`, focusing on grammar corrections, clarity enhancements, and better alignment with the UNIX philosophy of modular tools. Below is a summary of the most important changes:

### Grammar and Clarity Improvements:
* Corrected minor grammatical issues, such as adding missing periods and fixing typos like "will will" to "we will" and "challenege" to "challenge" (`content/posts/2025-06-23-oidc-cli-intro/index.md`). [[1]](diffhunk://#diff-25a15c2b9aa31fac2b5bc8959cc589e4bab303e0c756536a93c9b01530a7463bL48-R56) [[2]](diffhunk://#diff-25a15c2b9aa31fac2b5bc8959cc589e4bab303e0c756536a93c9b01530a7463bL101-R101) [[3]](diffhunk://#diff-25a15c2b9aa31fac2b5bc8959cc589e4bab303e0c756536a93c9b01530a7463bL120-R120)

### Enhanced Descriptions:
* Improved the description of `oidc-cli`'s compatibility with other CLI tools by emphasizing its adherence to the UNIX philosophy of modular commands with clear input and output streams (`content/posts/2025-06-23-oidc-cli-intro/index.md`).

### Flow and Readability:
* Refined phrasing to make the text more concise and easier to follow, such as rewording "invocations to be chained together with other CLI tools" to "invocations to be chained with commands" (`content/posts/2025-06-23-oidc-cli-intro/index.md`).